### PR TITLE
Fixes lookup if the default branch is not master

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ function ls (path, callback) {
   var slug = parts[4]
   var branch = parts[6] || 'master'
   var folder = parts[7]
-  var rev
   var prefix
   if (folder) {
     folder += '/'
@@ -30,7 +29,6 @@ function ls (path, callback) {
     }))
   })
   ls.paths(GITHUB, slug, 'branches', ls.errorCatch(callback, function (list) {
-
     for (var i = 0; i < list.length; i++) {
       var item = list[i]
       prefix = 'branches/' + branch + '/'

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function ls (path, callback) {
   ls.paths(GITHUB, slug, 'branches', ls.errorCatch(callback, function (list) {
     for (var i = 0; i < list.length; i++) {
       var item = list[i]
-      prefix = 'branches/' + branch + '/'
+      prefix = 'branches/' + branch + '/' + folder
       if (item.path === prefix) {
         /*
          This branch is actually a branch! lets use it!
@@ -45,7 +45,7 @@ function ls (path, callback) {
       read
      */
     ls.paths(GITHUB, slug, '', ls.errorCatch(callback, function (list) {
-      prefix = 'trunk/'
+      prefix = 'trunk/' + folder
       ls.paths(GITHUB, slug, list[0].rev + folder, folderProcessor)
     }))
   }))


### PR DESCRIPTION
The SVN implementation of github doesn't seem to be mapping trunk to master but rather trunk to the default branch. This pull request considers that fact.